### PR TITLE
Floor heating parse add timer data only if present

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -976,7 +976,8 @@ module.exports = {
   // 11.1.2 Response Read Floor Heating Status
   0x1945: {
     parse: function(buffer) {
-      return {
+      var length = buffer.length;
+      var data = {
         status: Boolean(buffer.readUInt8(2)),
         mode: buffer.readUInt8(3),
 
@@ -987,10 +988,13 @@ module.exports = {
           day: buffer.readUInt8(5),
           night: buffer.readUInt8(6),
           away: buffer.readUInt8(7)
-        },
-
-        timer: buffer.readUInt8(8)
+        }
       };
+
+      if (length >= 9)
+        data.timer = buffer.readUInt8(8);
+
+      return data;
     },
 
     encode: function(data) {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -998,7 +998,8 @@ module.exports = {
     },
 
     encode: function(data) {
-      var buffer = new Buffer(9);
+      var timerPresent = (data.timer == undefined) ? 0 : 1;
+      var buffer = new Buffer(8 + timerPresent);
       var temperature = data.temperature;
 
       buffer.writeUInt8(temperature.type, 0);
@@ -1009,7 +1010,9 @@ module.exports = {
       buffer.writeUInt8(temperature.day, 5);
       buffer.writeUInt8(temperature.night, 6);
       buffer.writeUInt8(temperature.away, 7);
-      buffer.writeUInt8(data.timer, 8);
+
+      if ( data.timer != undefined )
+        buffer.writeUInt8(data.timer, 8);
 
       return buffer;
     }

--- a/test/fixtures/commands.js
+++ b/test/fixtures/commands.js
@@ -374,22 +374,40 @@ module.exports = {
   // '0x1944'
 
   // 11.1.2 Response Read Floor Heating Status
-  '0x1945': {
-    data: new Buffer('001800011414141401', 'hex'),
-    object: {
-      temperature: {
-        type: 0,
-        current: 24,
-        normal: 20,
-        day: 20,
-        night: 20,
-        away: 20
-      },
-      status: false,
-      mode: 1,
-      timer: 1
+  '0x1945': [
+    {
+      data: new Buffer('001800011414141401', 'hex'),
+      object: {
+        temperature: {
+          type: 0,
+          current: 24,
+          normal: 20,
+          day: 20,
+          night: 20,
+          away: 20
+        },
+        status: false,
+        mode: 1,
+        timer: 1
+      }
+    },
+    {
+      data: new Buffer('0018000114141414', 'hex'),
+      object: {
+        temperature: {
+          type: 0,
+          current: 24,
+          normal: 20,
+          day: 20,
+          night: 20,
+          away: 20
+        },
+        status: false,
+        mode: 1
+      }
     }
-  },
+  ],
+
 
   // 11.1.3 Control Floor Heating Status
   '0x1946': {


### PR DESCRIPTION
Why: This fixes a crash generated (`RangeError('Index out of range')`) if there is no timer data in the buffer from a floor heating in DLP.